### PR TITLE
Add new command for checking external symbols

### DIFF
--- a/auditwheel/main.py
+++ b/auditwheel/main.py
@@ -7,7 +7,7 @@ import pkg_resources
 from . import main_show
 from . import main_addtag
 from . import main_lddtree
-
+from . import main_symbols
 
 def main():
     dist = pkg_resources.get_distribution('auditwheel')
@@ -28,6 +28,7 @@ def main():
     main_show.configure_parser(sub_parsers)
     main_addtag.configure_parser(sub_parsers)
     main_lddtree.configure_subparser(sub_parsers)
+    main_symbols.configure_subparser(sub_parsers)
 
     args = p.parse_args()
 

--- a/auditwheel/main_symbols.py
+++ b/auditwheel/main_symbols.py
@@ -1,4 +1,4 @@
-"""The runtime dynamic linker that loads your Python extension module when it's imported doesn't have the same concept of namespaces that exists in Python, so it's possibe for symbols defined in one module to automatically, at runtime override symbols defined or used in another file, in ways that the author of that module probably didn't intend.
+"""The runtime dynamic linker that loads your Python extension module when it's imported doesn't have the same concept of namespaces that exists in Python, so it's possibe for symbols defined in one module to automatically, at runtime, override symbols defined or used in another file, in ways that the author of that module probably didn't intend.
 
 (This why tricks line LD_PRELOAD work.)
 

--- a/auditwheel/main_symbols.py
+++ b/auditwheel/main_symbols.py
@@ -1,8 +1,8 @@
-"""The runtime dynamic linker that loads your Python extension module when it's imported doesn't have the same concept of namespaces that exists in Python, so it's possibe for symbols defined in one module to automatically, at runtime, override symbols defined or used in another file, in ways that the author of that module probably didn't intend.
+"""The runtime dynamic linker that loads your Python extension module when it's imported doesn't have the same concept of namespaces that exists in Python, so it's possible for symbols defined in one module to automatically, at runtime, override symbols defined or used in another file, in ways that the author of that module probably didn't intend.
 
 (This why tricks line LD_PRELOAD work.)
 
-It's therefore good practice to limit the number of dynmic symbols that your module adds to the global symbol namespace.
+It's therefore good practice to limit the number of dynamic symbols that your module adds to the global symbol namespace.
 
 This tool will print all of the (unnecessary) symbols that a wheel exports. We recommend that you try to keep this list as short as possible.
 

--- a/auditwheel/main_symbols.py
+++ b/auditwheel/main_symbols.py
@@ -1,6 +1,6 @@
 """The runtime dynamic linker that loads your Python extension module when it's imported doesn't have the same concept of namespaces that exists in Python, so it's possible for symbols defined in one module to automatically, at runtime, override symbols defined or used in another file, in ways that the author of that module probably didn't intend.
 
-(This why tricks line LD_PRELOAD work.)
+(This why tricks like LD_PRELOAD work.)
 
 It's therefore good practice to limit the number of dynamic symbols that your module adds to the global symbol namespace.
 

--- a/auditwheel/main_symbols.py
+++ b/auditwheel/main_symbols.py
@@ -1,0 +1,67 @@
+"""The runtime dynamic linker that loads your Python extension module when it's imported doesn't have the same concept of namespaces that exists in Python, so it's possibe for symbols defined in one module to automatically, at runtime override symbols defined or used in another file, in ways that the author of that module probably didn't intend.
+
+(This why tricks line LD_PRELOAD work.)
+
+It's therefore good practice to limit the number of dynmic symbols that your module adds to the global symbol namespace.
+
+This tool will print all of the (unnecessary) symbols that a wheel exports. We recommend that you try to keep this list as short as possible.
+
+For more information on how to control visibility during compilation, see https://gcc.gnu.org/wiki/Visibility. We recommend compiling with -fvisibility=hidden and explicitly labeling only functions you want to export with ``__attribute__ ((visibility ("default")))``.
+
+For more information on the meaning of STV_DEFAULT, STB_GLOBAL, and the like,
+see http://www.sco.com/developers/gabi/2000-07-17/ch4.symtab.html.
+"""
+import argparse
+import textwrap
+
+
+def configure_subparser(sub_parsers):
+    help = "List symbols exported by shared libraries in this wheel."
+    description = '\n\n'.join('\n'.join(textwrap.wrap(p))
+                              for p in __doc__.split('\n\n'))
+
+    p = sub_parsers.add_parser(
+        'symbols',
+        help=help,
+        description=description,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument('WHEEL_FILE', help='Path to wheel file.')
+    p.add_argument(
+        '-w',
+        '--whitelist',
+        dest='WHITELIST_FILE',
+        help=
+        'Skip any symbol names that appear in this file (plaintext, one per line).')
+    p.set_defaults(func=execute)
+
+
+def execute(args, p):
+    from .symbolcheck import iter_wheel_exposed_symbols
+
+    if args.WHITELIST_FILE is not None:
+        with open(args.WHITELIST_FILE) as f:
+            whitelist = {line.strip() for line in f}
+            filterfunc = lambda sym: sym not in whitelist
+    else:
+        filterfunc = lambda x: True
+
+    symbols = sorted(filter(filterfunc, iter_wheel_exposed_symbols(
+        args.WHEEL_FILE)))
+
+    header = [['File', 'Symbol Name', 'Visibility', 'Binding'],
+              ['----', '-----------', '----------', '-------']]
+
+    for row in format_table(header + symbols):
+        print(row)
+    print('\n%d symbols' % len(symbols))
+
+
+def format_table(rows):
+    # Reorganize data by columns
+    cols = zip(*rows)
+    # Compute column widths by taking maximum length of values per column
+    col_widths = [2 + max(len(value) for value in col) for col in cols]
+    # Create a suitable format string
+    fmt = ' '.join(['%%-%ds' % width for width in col_widths])
+    for row in rows:
+        yield fmt % tuple(row)

--- a/auditwheel/symbolcheck.py
+++ b/auditwheel/symbolcheck.py
@@ -1,0 +1,76 @@
+import re
+from itertools import repeat
+from os.path import basename
+from typing import Iterator, Tuple
+
+from .genericpkgctx import InGenericPkgCtx
+from .lddtree import elf_file_filter, elf_match_dt_needed
+from .policy.external_references import LIBPYTHON_RE
+
+LIBPYTHONS_RE = {
+    2: re.compile('^libpython2\.\dm?.so(.\d)*$'),
+    3: re.compile('^libpython3\.\dm?.so(.\d)*$')
+}
+
+
+def iter_wheel_exposed_symbols(wheel_file: str) -> Iterator[Tuple[str, str, str, str]]:
+    """Get all of the exposed symbols in the dynamic shared object
+    files in a wheel.
+    """
+    with InGenericPkgCtx(wheel_file) as ctx:
+        for fn, elf in elf_file_filter(ctx.iter_files()):
+            links_python = False
+            prepend_fn = lambda: (basename(fn), ) + t,
+            
+            for py_major_ver, py_re in LIBPYTHONS_RE.items():
+                if elf_match_dt_needed(elf, py_re):
+                    links_python = True
+
+                    yield from map(
+                        lambda t: (basename(fn), ) + t, filter_init_symbol(
+                            iter_elf_exposed_symbols(elf), py_major_ver, fn))
+
+            if not links_python:
+                yield from map(lambda t: (basename(fn), ) + t,
+                               iter_elf_exposed_symbols(elf))
+
+
+def iter_elf_exposed_symbols(elf) -> Iterator[Tuple[str, str, str]]:
+    """Get all the "exposed" symbols in an ELF.
+
+    By "exposed", we mean symbols that
+    1. Have STB_GLOBAL, described as:
+        Global symbols are visible to all object files being combined.
+        One file's definition of a global symbol will satisfy another
+        file's undefined reference to the same global symbol.
+        (http://www.sco.com/developers/gabi/latest/ch4.symtab.html)
+    2. Are defined in this ELF file.
+    3. Are functions (we could check for other stuff like data,
+       but I'm seeing some false positives there)
+    """
+
+    def is_exposed(s):
+        return (s.name not in (b'_init', b'_fini') and
+                s['st_info']['type'] == 'STT_FUNC' and
+                s['st_shndx'] != 'SHN_UNDEF' and (
+                    s['st_other']['visibility'] == 'STV_DEFAULT' or
+                    s['st_info']['bind'] == 'STB_GLOBAL'))
+
+    sect = elf.get_section_by_name(b'.dynsym')
+    if sect is not None:
+        for s in filter(is_exposed, sect.iter_symbols()):
+            yield (s.name.decode('utf-8'), s['st_other']['visibility'],
+                   s['st_info']['bind'])
+
+
+def filter_init_symbol(symbols: Iterator[Tuple[str,str,str]], py_major_ver: int, fn:
+                       str) -> Iterator[Tuple[str,str,str]]:
+    """Filter out the module initialization function's name
+    (init<modname> or PyInit_<modname> required by the CPython C API
+    """
+    modname = basename(fn).split('.', 1)[0]
+    module_init_f = {2: 'init', 3: 'PyInit_'}[py_major_ver] + modname
+
+    for s in symbols:
+        if s[0] != module_init_f:
+            yield s


### PR DESCRIPTION
Implements https://github.com/rmcgibbo/deloc8/issues/1. Here's the help text. Any corrections or rephrasings would be greatly appreciated:

```
$ auditwheel symbols -h
usage: auditwheel symbols [-h] [-w WHITELIST_FILE] WHEEL_FILE

The runtime dynamic linker that loads your Python extension module
when it's imported doesn't have the same concept of namespaces that
exists in Python, so it's possible for symbols defined in one module
to automatically, at runtime, override symbols defined or used in
another file, in ways that the author of that module probably didn't
intend.

(This why tricks like LD_PRELOAD work.)

It's therefore good practice to limit the number of dynamic symbols
that your module adds to the global symbol namespace.

This tool will print all of the (unnecessary) symbols that a wheel
exports. We recommend that you try to keep this list as short as
possible.

For more information on how to control visibility during compilation,
see https://gcc.gnu.org/wiki/Visibility. We recommend compiling with
-fvisibility=hidden and explicitly labeling only functions you want to
export with ``__attribute__ ((visibility ("default")))``.

For more information on the meaning of STV_DEFAULT, STB_GLOBAL, and
the like, see
http://www.sco.com/developers/gabi/2000-07-17/ch4.symtab.html.

positional arguments:
  WHEEL_FILE            Path to wheel file.

optional arguments:
  -h, --help            show this help message and exit
  -w WHITELIST_FILE, --whitelist WHITELIST_FILE
                        Skip any symbol names that appear in this file
                        (plaintext, one per line).
```

Also, @njsmith, here's the output for numpy: https://gist.github.com/rmcgibbo/4b06409dd7f6d16a8bf2