### PR TITLE
Update policy.json

### DIFF
--- a/auditwheel/policy/policy.json
+++ b/auditwheel/policy/policy.json
@@ -19,6 +19,7 @@
          "libc.so.6", "libnsl.so.1", "libutil.so.1", "libpthread.so.0",
          "libX11.so.6", "libXext.so.6", "libXrender.so.1", "libICE.so.6",
          "libSM.so.6", "libGL.so.1", "libgobject-2.0.so.0",
-         "libgthread-2.0.so.0", "libglib-2.0.so.0"
+         "libgthread-2.0.so.0", "libglib-2.0.so.0", "libgmodule-2.0.so.0",
+         "libgio-2.0.so.0"
      ]}
 ]


### PR DESCRIPTION
The policy includes right now about half the shared libraries included in libglib. This adds the other two. (https://packages.debian.org/jessie/amd64/libglib2.0-0/filelist). cc @njsmith 