### PR TITLE
Put RUNPATH before LD_LIBRARY_PATH

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,4 @@ script:
 
   - find wheelhouse-* -name '*.whl' | xargs -n1 -I '{}' sh -c "auditwheel show '{}'; echo ----------; echo ---------- "
   - find wheelhouse-* -name '*.whl' | xargs -n1 -I '{}' sh -c "auditwheel repair '{}'; echo ----------; echo ---------- "
-  - find wheelhouse-* -name '*.whl' | xargs -n1 -I '{}' sh -c "auditwheel show '{}'; echo ----------; echo ---------- "
+  - find wheelhouse/ -name '*.whl' | xargs -n1 -I '{}' sh -c "auditwheel show '{}'; echo ----------; echo ---------- "

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,10 @@ script:
   - PYVER=$(python -c "import sys; print('.'.join(map(str, sys.version_info[:2])))")
   - wget "https://github.com/getnikola/wheelhouse/archive/v${PYVER}.zip"
   - unzip v${PYVER}.zip
+
   - URL=http://vorpus.org/~njs/tmp/manylinux-test-wheels/original/
   - curl --silent $URL | grep 'a href' | grep whl | cut -d ' ' -f 8 | cut -d '=' -f 2 | cut -d '"' -f 2 | xargs -n1 -I '{}' wget -P wheelhouse-njs "$URL/{}" 
+
+  - find wheelhouse-* -name '*.whl' | xargs -n1 -I '{}' sh -c "auditwheel show '{}'; echo ----------; echo ---------- "
+  - find wheelhouse-* -name '*.whl' | xargs -n1 -I '{}' sh -c "auditwheel repair '{}'; echo ----------; echo ---------- "
   - find wheelhouse-* -name '*.whl' | xargs -n1 -I '{}' sh -c "auditwheel show '{}'; echo ----------; echo ---------- "

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,6 @@ script:
   - PYVER=$(python -c "import sys; print('.'.join(map(str, sys.version_info[:2])))")
   - wget "https://github.com/getnikola/wheelhouse/archive/v${PYVER}.zip"
   - unzip v${PYVER}.zip
+  - URL=http://vorpus.org/~njs/tmp/manylinux-test-wheels/original/
+  - curl --silent $URL | grep 'a href' | grep whl | cut -d ' ' -f 8 | cut -d '=' -f 2 | cut -d '"' -f 2 | xargs -n1 -I '{}' wget -P wheelhouse-njs "$URL/{}" 
   - find wheelhouse-* -name '*.whl' | xargs -n1 -I '{}' sh -c "auditwheel show '{}'; echo ----------; echo ---------- "

--- a/auditwheel/lddtree.py
+++ b/auditwheel/lddtree.py
@@ -404,9 +404,9 @@ def parse_elf(path: str,
             if lib in _all_libs:
                 continue
             if all_ldpaths is None:
-                all_ldpaths = rpaths + ldpaths['rpath'] + ldpaths[
-                    'env'] + runpaths + ldpaths['runpath'] + ldpaths[
-                        'conf'] + ldpaths['interp']
+                all_ldpaths = rpaths + ldpaths['rpath'] + runpaths + \
+                              ldpaths['env'] + ldpaths['runpath'] + ldpaths['conf'] + \
+                              ldpaths['interp']
             realpath, fullpath = find_lib(elf, lib, all_ldpaths, root)
             _all_libs[lib] = {
                 'realpath': realpath,

--- a/auditwheel/main_show.py
+++ b/auditwheel/main_show.py
@@ -14,6 +14,7 @@ def printp(text):
 def execute(args, p):
     import json
     from functools import reduce
+    from collections import OrderedDict
     from os.path import isfile, basename
     from .policy import (load_policies, get_priority_by_name,
                          POLICY_PRIORITY_LOWEST, POLICY_PRIORITY_HIGHEST,
@@ -53,7 +54,7 @@ def execute(args, p):
     else:
         printp(('The following external shared libraries are required '
                 'by the wheel:'))
-        print(json.dumps(libs, indent=4))
+        print(json.dumps(OrderedDict(sorted(libs.items())), indent=4))
 
     for p in sorted(load_policies(), key=lambda p: p['priority']):
         if p['priority'] > get_priority_by_name(winfo.overall_tag):

--- a/auditwheel/repair.py
+++ b/auditwheel/repair.py
@@ -38,6 +38,10 @@ def repair_wheel(wheel_path: str, abi: str, lib_sdir: str, out_dir:
 
             ext_libs = v[abi]['libs']  # type: Dict[str, str]
             for libname, src_path in ext_libs.items():
+                if src_path is None:
+                    raise ValueError('Cannot repair wheel, because required '
+                                     'library "%s" could not be located')
+
                 dest_path = os.path.join(dest_dir, libname)
                 if not os.path.exists(dest_path):
                     print('Grafting: %s' % src_path)

--- a/auditwheel/repair.py
+++ b/auditwheel/repair.py
@@ -39,8 +39,9 @@ def repair_wheel(wheel_path: str, abi: str, lib_sdir: str, out_dir:
             ext_libs = v[abi]['libs']  # type: Dict[str, str]
             for libname, src_path in ext_libs.items():
                 if src_path is None:
-                    raise ValueError('Cannot repair wheel, because required '
-                                     'library "%s" could not be located')
+                    raise ValueError(('Cannot repair wheel, because required '
+                                      'library "%s" could not be located') %
+                                     libname)
 
                 dest_path = os.path.join(dest_dir, libname)
                 if not os.path.exists(dest_path):

--- a/auditwheel/repair.py
+++ b/auditwheel/repair.py
@@ -40,8 +40,8 @@ def repair_wheel(wheel_path: str, abi: str, lib_sdir: str, out_dir:
             for libname, src_path in ext_libs.items():
                 dest_path = os.path.join(dest_dir, libname)
                 if not os.path.exists(dest_path):
-                    shutil.copy2(src_path, dest_path)
                     print('Grafting: %s' % src_path)
+                    shutil.copy2(src_path, dest_path)
 
             if len(ext_libs) > 0:
                 patchelf(fn, dest_dir)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,3 @@
 pytest
 jsonschema
+pypatchelf


### PR DESCRIPTION
@njsmith: I think this might fix the issue on your platform with pyside (?). The linker searches RPATH, then LD_LIBRARY_PATH, then RUNPATH, but for the purpose of determining what libs to copy into the wheel, as you pointed out by email, it makes more sense to search RUNPATH first.